### PR TITLE
Doc: Update appsearch docs to support integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 2.0.0
+## Next
+- [DOC] Updates output-elastic_app_search documentation to add an integration attribute and include the integration plugin header [#5](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/5)
 
+## 2.0.0
 - Initial release of the Elastic EnterpriseSearch Integration Plugin, which carries the
   previous AppSearch Output plugin codebase; 
   independent changelogs for previous versions can be found:

--- a/docs/output-elastic_app_search.asciidoc
+++ b/docs/output-elastic_app_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_app_search
 :type: output
 :no_codec:
@@ -17,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Elastic App Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
@@ -38,7 +39,7 @@ to store the timestamp in a different field.
 NOTE: This gem does not support codec customization.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== AppSearch Output Configuration Options
+==== AppSearch Output configuration options
 
 This plugin supports the following configuration options plus the
 <<plugins-{type}s-{plugin}-common-options>> described later.


### PR DESCRIPTION
## Release notes
[rn:skip] Use changelog entry picked up by the release notes script

## What does this PR do?
Output-elastic_app_search was recently converted from a stand-alone plugin to an element of integration-elastic_enterprise_search. This PR updates the doc file to add an `integration` attribute and switch the plugin header from one appropriate for a stand-alone plugin to the integration plugin header. 
