### PR TITLE
Doc: Remove link to file that doesn't exist yet

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,10 +21,9 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-The Elastic EnterpriseSearch Integration Plugin provides integrated plugins for working with
-App Search and Workplace Search services:
+The Elastic Enterprise Search integration plugin provides integrated plugins for working with App Search and Workplace Search services:
 
-- {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
-- {logstash-ref}/plugins-outputs-elastic_workplace_search.html[Workplace Search Output Plugin]
+*  {logstash-ref}/plugins-outputs-elastic_app_search.html[App Search Output Plugin]
+*  Workplace Search Output Plugin
 
 :no_codec!:


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
After review, we hardcoded a link in #5 to avoid pointing to a page that doesn't exist yet, but somehow the fix got stomped before merge. This PR hardcodes the link until the file exists and we can replace it with #6.

**NOTE:** No version bump is required at this time. 