### PR TITLE
Doc: Add integration attribute and replace plugin header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 2.1.1
+- [DOC] Added the integration attribute and include statement for the integration plugin header to finalize hooking up integration docs [#8](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/8)
+- [DOC] Added live link to output-elastic_workplace_search doc [#6](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/6)
+
 ## 2.1.0
 - Addition of Workplace Search Output plugin [#4](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/4)
-- [DOC] Updates output-elastic_app_search documentation to add an integration attribute and include the integration plugin header [#5](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/5)
+- [DOC] Added the integration attribute and include statement for the integration plugin header to output-elastic_app_search doc [#5](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/5)
 
 
 ## 2.0.0

--- a/docs/output-elastic_workplace_search.asciidoc
+++ b/docs/output-elastic_workplace_search.asciidoc
@@ -1,3 +1,4 @@
+:integration: elastic_enterprise_search
 :plugin: elastic_workplace_search
 :type: output
 :no_codec:
@@ -17,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Elastic Workplace Search output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-integration-elastic_enterprise_search'
-  s.version         = '2.1.0'
+  s.version         = '2.1.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Elastic Enterprise Search - output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
## Release notes
[rn:skip]  [Use changelog entry]


## What does this PR do?
Adds `:integration:`attribute and replaces basic plugin header with integration header in  output-elastic_workplace_search.asciidoc
