### PR TITLE
[Doc] fix plugin name in configuration sample

### DIFF
--- a/docs/output-elastic_app_search.asciidoc
+++ b/docs/output-elastic_app_search.asciidoc
@@ -119,7 +119,7 @@ filter {
 }
 
 output {
-  appsearch {
+  elastic_app_search {
     engine => "engine_%{[engine_name]}"
   }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Fixes the name of plugin in configuration sample used in documentation, from `appsearch` to `enterprise_app_search`
