### PR TITLE
declare deprecation of enterprise search plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+ - Add deprecation log for App Search and Workplace Search. Both are removed from Elastic Stack in version 9
+
 ## 3.0.0
  - Bumped Enterprise Search clients to version `>= 7.16`, `< 9` [#18](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/18)
  - Added support to SSL configurations (`ssl_certificate_authorities`, `ssl_truststore_path`, `ssl_truststore_password`, `ssl_truststore_type`, `ssl_verification_mode`, `ssl_supported_protocols` and `ssl_cipher_suites`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.1
- - Add deprecation log for App Search and Workplace Search. Both are removed from Elastic Stack in version 9
+ - Add deprecation log for App Search and Workplace Search. Both products are removed from Elastic Stack in version 9 [#22](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/22)
 
 ## 3.0.0
  - Bumped Enterprise Search clients to version `>= 7.16`, `< 9` [#18](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/18)

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -48,7 +48,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
   def register
     log_message = "The App Search product is deprecated and not supported from version 9 of the Elastic Stack. " +
       "The Elastic App Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
-      "Please migrate to the Elasticsearch Connector for continued support." +
+      "Please migrate to the Elastic Connector for continued support. " +
       "For more details, please visit https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch.html"
     deprecation_logger.deprecated log_message
 

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -47,7 +47,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
 
   def register
     log_message = "The App Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
-      "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
+      "The Elastic App Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
     deprecation_logger.deprecated log_message

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -48,7 +48,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
   def register
     log_message = "The App Search product is deprecated and not supported from version 9 of the Elastic Stack. " +
       "The Elastic App Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
-      "We recommend transitioning to our native Elasticsearch tools. " +
+      "Please migrate to the Elasticsearch Connector for continued support." +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
     deprecation_logger.deprecated log_message
 

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -49,7 +49,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
     log_message = "The App Search product is deprecated and not supported from version 9 of the Elastic Stack. " +
       "The Elastic App Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "Please migrate to the Elasticsearch Connector for continued support." +
-      "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
+      "For more details, please visit https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch.html"
     deprecation_logger.deprecated log_message
 
     @retry_disabled = false

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -45,8 +45,8 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
   ENGINE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
-    log_message = "The App Search product is deprecated as of version 9 of the Elastic Stack. " +
-      "It will only receive security updates. " +
+    log_message = "The App Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
+      "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
     @deprecation_logger.deprecated log_message

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -7,6 +7,7 @@ require 'logstash/plugin_mixins/enterprise_search/client'
 class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
 
   include LogStash::PluginMixins::EnterpriseSearch::SSLConfigs
+  include LogStash::PluginMixins::DeprecationLoggerSupport
 
   config_name 'elastic_app_search'
 
@@ -49,7 +50,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
       "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
-    @deprecation_logger.deprecated log_message
+    deprecation_logger.deprecated log_message
 
     @retry_disabled = false
     @client = LogStash::PluginMixins::EnterpriseSearch::AppSearch::Client.new(client_options, params: params)

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'logstash/outputs/base'
+require 'logstash/plugin_mixins/deprecation_logger_support'
 require 'logstash/plugin_mixins/enterprise_search/ssl_configs'
 require 'logstash/plugin_mixins/enterprise_search/client'
 
@@ -44,6 +45,12 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
   ENGINE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
+    log_message = "The App Search product is deprecated as of version 9 of the Elastic Stack. " +
+      "It will only receive security updates. " +
+      "We recommend transitioning to our native Elasticsearch tools. " +
+      "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
+    @deprecation_logger.deprecated log_message
+
     @retry_disabled = false
     @client = LogStash::PluginMixins::EnterpriseSearch::AppSearch::Client.new(client_options, params: params)
     check_connection!

--- a/lib/logstash/outputs/elastic_app_search.rb
+++ b/lib/logstash/outputs/elastic_app_search.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::ElasticAppSearch < LogStash::Outputs::Base
   ENGINE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
-    log_message = "The App Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
+    log_message = "The App Search product is deprecated and not supported from version 9 of the Elastic Stack. " +
       "The Elastic App Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"

--- a/lib/logstash/outputs/elastic_workplace_search.rb
+++ b/lib/logstash/outputs/elastic_workplace_search.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'logstash/outputs/base'
+require 'logstash/plugin_mixins/deprecation_logger_support'
 require 'logstash/plugin_mixins/enterprise_search/client'
 require 'logstash/plugin_mixins/enterprise_search/ssl_configs'
 
@@ -43,6 +44,12 @@ class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
   SOURCE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
+    log_message = "The Workplace Search product is deprecated as of version 9 of the Elastic Stack. " +
+      "It will only receive security updates. " +
+      "We recommend transitioning to our native Elasticsearch tools. " +
+      "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
+    @deprecation_logger.deprecated log_message
+
     @retry_disabled = false
     @client = LogStash::PluginMixins::EnterpriseSearch::WorkplaceSearch::Client.new(client_options, params: params)
     begin

--- a/lib/logstash/outputs/elastic_workplace_search.rb
+++ b/lib/logstash/outputs/elastic_workplace_search.rb
@@ -7,6 +7,7 @@ require 'logstash/plugin_mixins/enterprise_search/ssl_configs'
 class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
 
   include LogStash::PluginMixins::EnterpriseSearch::SSLConfigs
+  include LogStash::PluginMixins::DeprecationLoggerSupport
 
   config_name 'elastic_workplace_search'
 
@@ -48,7 +49,7 @@ class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
       "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
-    @deprecation_logger.deprecated log_message
+    deprecation_logger.deprecated log_message
 
     @retry_disabled = false
     @client = LogStash::PluginMixins::EnterpriseSearch::WorkplaceSearch::Client.new(client_options, params: params)

--- a/lib/logstash/outputs/elastic_workplace_search.rb
+++ b/lib/logstash/outputs/elastic_workplace_search.rb
@@ -45,10 +45,10 @@ class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
   SOURCE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
-    log_message = "The Workplace Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
+    log_message = "The Workplace Search product is deprecated and not supported from version 9 of the Elastic Stack. " +
       "The Elastic Workplace Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
-      "We recommend transitioning to our native Elasticsearch tools. " +
-      "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
+      "Please migrate to the Elastic Connector for continued support. " +
+      "For more details, please visit https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch.html"
     deprecation_logger.deprecated log_message
 
     @retry_disabled = false

--- a/lib/logstash/outputs/elastic_workplace_search.rb
+++ b/lib/logstash/outputs/elastic_workplace_search.rb
@@ -44,8 +44,8 @@ class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
   SOURCE_WITH_SPRINTF_REGEX = /^.*%\{.+\}.*$/.freeze
 
   def register
-    log_message = "The Workplace Search product is deprecated as of version 9 of the Elastic Stack. " +
-      "It will only receive security updates. " +
+    log_message = "The Workplace Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
+      "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
     @deprecation_logger.deprecated log_message

--- a/lib/logstash/outputs/elastic_workplace_search.rb
+++ b/lib/logstash/outputs/elastic_workplace_search.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::ElasticWorkplaceSearch < LogStash::Outputs::Base
 
   def register
     log_message = "The Workplace Search product is deprecated and excluded from the version 9 of the Elastic Stack. " +
-      "This plugin is deprecated and will only receive security updates and critical bug fixes. " +
+      "The Elastic Workplace Search output plugin is deprecated and will only receive security updates and critical bug fixes. " +
       "We recommend transitioning to our native Elasticsearch tools. " +
       "For more details, please visit https://www.elastic.co/guide/en/enterprise-search/current/app-search-workplace-search.html"
     deprecation_logger.deprecated log_message

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-integration-elastic_enterprise_search'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Elastic Enterprise Search - output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
The Enterprise Search product is deprecated and will not be included in the Elastic Stack 9.x release.
As a result, the App Search and Workplace Search plugins are also deprecated. These plugins will only receive security updates and critical bug fixes moving forward.

This commit added deprecation log

fixes: https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/issues/20, https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/issues/21