### PR TITLE
Upgrade elastic-enterprise-search gem, tolerate newer elastiscearch ruby client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0
+## 3.0.2
   - Upgrades `elastic-enterprise-search` gem and tolerates `Elastic::Transport` client [#26](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/26)
 
 ## 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Upgrades `elastic-enterprise-search` gem and tolerates `Elastic::Transport` client [#26](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/26)
+
 ## 3.0.1
  - Add deprecation log for App Search and Workplace Search. Both products are removed from Elastic Stack in version 9 [#22](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/pull/22)
 

--- a/lib/logstash/plugin_mixins/enterprise_search/manticore_transport.rb
+++ b/lib/logstash/plugin_mixins/enterprise_search/manticore_transport.rb
@@ -4,14 +4,29 @@ module LogStash::PluginMixins::EnterpriseSearch
   # It also provides common Manticore configurations such as :ssl.
   module ManticoreTransport
     def self.included(base)
-      if eps_version_7?
-        require 'elasticsearch/transport/transport/http/manticore'
-      else
-        require 'elastic/transport/transport/http/manticore'
-      end
+      load_transport!
 
       raise ArgumentError, "`#{base}` must inherit Elastic::EnterpriseSearch::Client" unless base < Elastic::EnterpriseSearch::Client
       raise ArgumentError, "`#{base}` must respond to :params" unless base.instance_methods.include? :params
+    end
+
+    # `elasticsearch-transport` is old, `elastic-transport` is the replacement.
+    # LS-core updated `elasticsearch` > 8: https://github.com/elastic/logstash/pull/17161
+    # Following logic supports both `elasticsearch-transport` and `elastic-transport` gems.
+    def self.load_transport!
+      return if @transport_loaded
+      begin
+        require 'elasticsearch/transport/transport/http/manticore'
+        @use_legacy_transport = true
+      rescue LoadError
+        require 'elastic/transport/transport/http/manticore'
+        @use_legacy_transport = false
+      end
+      @transport_loaded = true
+    end
+
+    def self.use_legacy_transport?
+      @use_legacy_transport
     end
 
     # overrides Elastic::EnterpriseSearch::Client#transport
@@ -33,24 +48,15 @@ module LogStash::PluginMixins::EnterpriseSearch
       )
     end
 
-    def self.eps_version_7?
-      Elastic::EnterpriseSearch::VERSION.start_with?('7')
-    end
-
     private
 
     def manticore_transport_klass
-      ManticoreTransport.eps_version_7? ? Elasticsearch::Transport::Transport::HTTP::Manticore : Elastic::Transport::Transport::HTTP::Manticore
+      ManticoreTransport.use_legacy_transport? ? Elasticsearch::Transport::Transport::HTTP::Manticore : Elastic::Transport::Transport::HTTP::Manticore
     end
 
     def transport_klass
-      if ManticoreTransport.eps_version_7?
-        case Elasticsearch::Transport::VERSION
-        when /^7\.1[123]/
-          Elasticsearch::Client
-        else
-          Elasticsearch::Transport::Client
-        end
+      if ManticoreTransport.use_legacy_transport?
+        Elasticsearch::Transport::Client
       else
         Elastic::Transport::Client
       end

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-integration-elastic_enterprise_search'
-  s.version         = '3.1.0'
+  s.version         = '3.0.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Elastic Enterprise Search - output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-integration-elastic_enterprise_search'
-  s.version         = '3.0.1'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Integration with Elastic Enterprise Search - output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+
                       "using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths   = ['lib', 'vendor/jar-dependencies']
 
   # Files

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
   # elastic-enterprise-search v9 not released yet
-  s.add_runtime_dependency 'elastic-enterprise-search', '>= 8.0', '< 9'
+  s.add_runtime_dependency 'elastic-enterprise-search', '~> 8.0'
   s.add_runtime_dependency "logstash-mixin-deprecation_logger_support", '~>1.0'
   s.add_development_dependency "logstash-devutils"
 end

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "manticore", '~> 0.8'
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
-  s.add_runtime_dependency 'elastic-enterprise-search', '>= 7.16', '< 9'
+  # elastic-enterprise-search v9 not released yet
+  s.add_runtime_dependency 'elastic-enterprise-search', '>= 8.0', '< 9'
   s.add_runtime_dependency "logstash-mixin-deprecation_logger_support", '~>1.0'
   s.add_development_dependency "logstash-devutils"
 end

--- a/spec/unit/outputs/manticore_transport_spec.rb
+++ b/spec/unit/outputs/manticore_transport_spec.rb
@@ -29,7 +29,7 @@ describe LogStash::PluginMixins::EnterpriseSearch::ManticoreTransport do
 
         result = client.transport
 
-        if LogStash::PluginMixins::EnterpriseSearch::ManticoreTransport.eps_version_7?
+        if LogStash::PluginMixins::EnterpriseSearch::ManticoreTransport.use_legacy_transport?
           expect(result.transport).to be_a(Elasticsearch::Transport::Transport::HTTP::Manticore)
         else
           expect(result.transport).to be_a(Elastic::Transport::Transport::HTTP::Manticore)


### PR DESCRIPTION
## What does this PR do?
Users with 8.17.3+ Logstash versions cannot install and run the plugin because they face `Uninitialized constant Elasticsearch::Transport` error. This PR fixes it.

## How to test this PR locally
```
./.ci/docker-setup.sh && ./.ci/docker-run.sh
```

Tested with `8.19.4-SNAPSHOT` and `8.17.1`. Note that we no longer publish `enterprise-search:9.x`, quick test: `ERROR: docker.elastic.co/enterprise-search/enterprise-search:9.3.1: not found`