### PR TITLE
Upgrade enterprise-search dependency to 8.19+

### DIFF
--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "manticore", '~> 0.8'
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
-  # elastic-enterprise-search v9 not released yet
-  s.add_runtime_dependency 'elastic-enterprise-search', '~> 8.0'
+  # elastic-enterprise-search is deprecated in v9 and gem for v9 is not released yet
+  s.add_runtime_dependency 'elastic-enterprise-search', '>= 8.19', '< 9'
   s.add_runtime_dependency "logstash-mixin-deprecation_logger_support", '~>1.0'
   s.add_development_dependency "logstash-devutils"
 end

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
   # elastic-enterprise-search is deprecated in v9 and gem for v9 is not released yet
-  s.add_runtime_dependency 'elastic-enterprise-search', '>= 8.19', '< 9'
+  s.add_runtime_dependency 'elastic-enterprise-search', '~> 8.19', 
   s.add_runtime_dependency "logstash-mixin-deprecation_logger_support", '~>1.0'
   s.add_development_dependency "logstash-devutils"
 end

--- a/logstash-integration-elastic_enterprise_search.gemspec
+++ b/logstash-integration-elastic_enterprise_search.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
   # elastic-enterprise-search is deprecated in v9 and gem for v9 is not released yet
-  s.add_runtime_dependency 'elastic-enterprise-search', '~> 8.19', 
+  s.add_runtime_dependency 'elastic-enterprise-search', '~> 8.19'
   s.add_runtime_dependency "logstash-mixin-deprecation_logger_support", '~>1.0'
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
Upgrades `elastic-enterprise-search` ruby gem to pull 8.19+ versions. This new version has fresh dependencies, especially vulnerabilities remedied like `jwt`.